### PR TITLE
Add ERL to description page. Close #151

### DIFF
--- a/description.Rmd
+++ b/description.Rmd
@@ -566,7 +566,7 @@ This metric is the ratio of the number 19- and 20-year olds with a high school d
 
 ### Domain: Work {#domain-work}
 
-##### PREDICTOR: EMPLOYMENT
+##### [PREDICTOR: EMPLOYMENT](https://upward-mobility.urban.org/employment-opportunities)
 
 **Metric: Employment-to-population ratio for adults ages 25 to 54**
 


### PR DESCRIPTION
I added the links to existing predictors in the description page. I added links for the new predictors to the Word doc referenced in #156.

These will almost certainly get shuffled around in the redesign, but this is sufficient for now. 